### PR TITLE
Adding Bink(1) notification

### DIFF
--- a/vagrant/provision/roles/icinga/files/commands.cfg
+++ b/vagrant/provision/roles/icinga/files/commands.cfg
@@ -34,6 +34,22 @@ define command {
        command_line      /usr/local/bin/slack_nagios.sh > /tmp/slack.log 2>&1
        }
 
+###############################
+# Blink1 notifications
+###############################
+
+# 'notify-service-by-blink1' command definition
+define command {
+       command_name     notify-service-by-blink1
+       command_line      /usr/local/bin/blink1_nagios.sh > /tmp/blink1.log 2>&1
+       }
+
+# 'notify-host-by-blink1' command definition
+define command {
+       command_name     notify-host-by-blink1
+       command_line      /usr/local/bin/blink1_nagios.sh > /tmp/blink1.log 2>&1
+       }
+
 
 ################################################################################
 # SAMPLE PERFORMANCE DATA COMMANDS

--- a/vagrant/provision/roles/icinga/tasks/main.yml
+++ b/vagrant/provision/roles/icinga/tasks/main.yml
@@ -42,3 +42,6 @@
 
 - sudo: yes
   copy: src=slack_nagios.sh dest=/usr/local/bin/slack_nagios.sh force=yes mode=0755
+
+- sudo: yes
+  template: src=blink_nagios.sh.j2 dest=/usr/local/bin/blink1_nagios.sh force=yes mode=0755

--- a/vagrant/provision/roles/icinga/templates/blink1_nagios.sh.j2
+++ b/vagrant/provision/roles/icinga/templates/blink1_nagios.sh.j2
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# This script is used by Nagios to post alerts to Hubot
+# Then Hubot can decide to notify Slack channels
+#
+# All variables that start with ICINGA_ are provided by Nagios as
+# environment variables when an notification is generated.
+# A list of the env variables is available here:
+#   http://nagios.sourceforge.net/docs/3_0/macrolist.html
+#
+
+#Modify these variables for your environment
+MY_ICINGA_HOSTNAME="monitoring.microservice.io"
+BLINK1_HOOK="http://{{ raspi_blink1_server_ip }}:{{ raspi_blink1_server_port }}/blink1/fadeToRGB"
+
+#Set the message icon based on Nagios service state
+if [ "$ICINGA_SERVICESTATE" = "CRITICAL" ]
+then
+    ICON=":exclamation:"
+    COLOR="%23D5573B"
+elif [ "$ICINGA_SERVICESTATE" = "WARNING" ]
+then
+    ICON=":warning:"
+    COLOR="%23FFB20F"
+elif [ "$ICINGA_SERVICESTATE" = "OK" ]
+then
+    ICON=":white_check_mark:"
+    COLOR="%2378BC61"
+elif [ "$ICINGA_SERVICESTATE" = "UNKNOWN" ]
+then
+    ICON=":question:"
+    COLOR="%232E86AB"
+else
+    ICON=":white_medium_square:"
+    COLOR="%232E86AB"
+fi
+
+#Send message to Blink1 mini server on Rapberry Pi
+curl ${BLINK1_HOOK}?rgb=${COLOR}&time=1.0                                              

--- a/vagrant/provision/vars/default.yml
+++ b/vagrant/provision/vars/default.yml
@@ -19,3 +19,10 @@ no_proxy: localhost,127.0.0.1,.hpecorp.net,ci-repo,monitoring-node,app-server-no
 proxy_env:
   http_proxy: "http://{{http_proxy_host}}:{{http_proxy_port}}"
   no_proxy: "{{no_proxy}}"
+
+# locate paspberryPi with Blink1 code
+# Fill in the located IP here and reprovision icinga
+# use this command  on the monitoringserver (elasticsearch) 
+#         sh ./provision.sh --limit=monitoring-node monitoringserver.yml
+raspi_blink1_server_ip: 16.22.89.101
+raspi_blink1_server_port: 8080


### PR DESCRIPTION
These are the modifications to push  icinga notifications  to Raspberry Pi Blink(1)

To use them we need to provision the IP of the Raspberry Pi in the followin file
the-app\vagrant\provision\vars\default.yml

It needs then to be propagated back to the icinga configuration: 
         sh ./provision.sh --limit=monitoring-node monitoringserver.yml
@ojacques  you want to edit this file before running the first lab on the instructor instance