### PR TITLE
Improved install speed and ci-repo issue fix

### DIFF
--- a/vagrant/provision/roles/debrepo/tasks/main.yml
+++ b/vagrant/provision/roles/debrepo/tasks/main.yml
@@ -39,9 +39,6 @@
 - file: path=/var/packages/debian/conf/override.shop state=touch force=yes
 - copy: src=options dest=/var/packages/debian/conf/options force=yes mode=0644
 
-- copy: src=default dest=/etc/nginx/sites-enabled/default force=yes mode=0644
-  notify: restart nginx
-
 - name: Check if ci-repo key exists.
   stat:
     path: /var/packages/ci-repo.gpg.key
@@ -55,3 +52,6 @@
 - sudo: yes
   sudo_user: root
   raw: reprepro -b /var/packages/debian/ export
+
+- copy: src=default dest=/etc/nginx/sites-enabled/default force=yes mode=0644
+  notify: restart nginx

--- a/vagrant/scripts/provision.sh
+++ b/vagrant/scripts/provision.sh
@@ -29,13 +29,13 @@ if grep -Fxq "with_proxy: true" vars/default.yml; then
    export https_proxy=http://${proxy_host}:${proxy_port}
 fi
 
-# Install or update ansible
-sudo -E apt-get update
-sudo -E apt-get install -y software-properties-common
-sudo -E apt-key add ansible.key.txt
-sudo -E apt-add-repository -y ppa:ansible/ansible
-sudo -E apt-get update
-sudo -E apt-get install -y --allow-unauthenticated ansible
+# Install or update ansible if not there
+if ! command -v ansible >/dev/null 2>&1; then
+  sudo -E apt-key add ansible.key.txt
+  sudo -E apt-add-repository -y ppa:ansible/ansible
+  sudo -E apt-get update
+  sudo -E apt-get install -y --allow-unauthenticated ansible software-properties-common
+fi
 
 echo "RUNNING ansible-playbook -c local --inventory-file=hosts --extra-vars='ansible_ssh_user=vagrant' --user=vagrant " $@
 


### PR DESCRIPTION
- Only install Ansible if not there to speed up reprovisioning
- Restart nginx after ci-repo is provisioned to fix errors about
  ci-repo.gpg.key not found