### PR TITLE
Fix elasticsearch stopping in the OpenStack environment

### DIFF
--- a/vagrant/provision/roles/elasticsearch/tasks/main.yml
+++ b/vagrant/provision/roles/elasticsearch/tasks/main.yml
@@ -22,4 +22,10 @@
       http.cors.enabled: true
       http.cors.allow-origin: http://monitoring.microservice.io
 
+- name: Setup unique elasticsearch cluster name
+  lineinfile:
+    dest: /etc/elasticsearch/elasticsearch.yml
+    regexp: '#cluster.name:\ elasticsearch'
+    line: 'cluster.name: "{{ 100 | random | to_uuid }}"'
+
 - raw: sudo service elasticsearch restart


### PR DESCRIPTION
Fix Elasticsearch failing in the Openstack setup, where all hosts from all pods are on the same subnet.

Per Quintin's guidance.