### PR TITLE
Put cluster.name in Ansible-managed block

### DIFF
--- a/vagrant/provision/roles/elasticsearch/tasks/main.yml
+++ b/vagrant/provision/roles/elasticsearch/tasks/main.yml
@@ -21,11 +21,6 @@
     block: |
       http.cors.enabled: true
       http.cors.allow-origin: http://monitoring.microservice.io
-
-- name: Setup unique elasticsearch cluster name
-  lineinfile:
-    dest: /etc/elasticsearch/elasticsearch.yml
-    regexp: '#cluster.name:\ elasticsearch'
-    line: 'cluster.name: "{{ 100 | random | to_uuid }}"'
+      cluster.name: {{ 100000 | random | to_uuid }}
 
 - raw: sudo service elasticsearch restart


### PR DESCRIPTION
This approach ensures that `cluster.name` entry is present only once
regardless of how many times the playbook is being run.

Fixes #122